### PR TITLE
ci: Added workflow to add all issues and PR to our GitHub board

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -1,0 +1,15 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  add-to-board:
+    uses: newrelic/node-newrelic/.github/workflows/board.yml@main
+    # See board.yml explaining why this has to be done
+    secrets:
+      gh_token: ${{ secrets.NODE_AGENT_GH_TOKEN }}
+


### PR DESCRIPTION
This workflow adds all issues and PRs to our shared engineering board. I'm waiting to assign the `NODE_AGENT_GH_TOKEN` to this repo.
