### PR TITLE
chore: Updated local repo dir processing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,16 +80,22 @@ modules.
 
 The following flags are supported:
 
+  -n, --no-externals           Disable cloning and processing of external repos. An external repo is
+                               one that provides extra functionality to the "newrelic" module. This
+                               allows processing a single repo with --repo-dir. The default, i.e. not
+                               supplying this flag, is to process all known external repos.
+                               
   -o, --output-format string   Specify the format to write the results as. The default is an ASCII
                                table. Possible values: "ascii" or "markdown".
-                                (default "ascii")
-  -r, --repo-dir string        Specify a local directory that contains the node-newrelic repo.
-                               If not provided, the GitHub repository will be cloned to a local temporary
-                               directory and that will be used.
-
+                                (default "markdown")
+  -r, --repo-dir string        Specify a local directory that contains a Node.js instrumentation repo.
+                               If not provided, the main agent GitHub repository will be cloned to a
+                               local temporary directory and that will be used.
+                               
   -t, --test-dir string        Specify the test directory to parse the package.json files.
-                               If not provided, it will default to 'test/versioned'.
-
+                               If not provided, it will default to 'test/versioned'. This applies to
+                               the repo provided by the --repo-dir flag.
+                                
   -v, --verbose                Enable verbose output. As the data is being loaded and parsed various
                                logs will be written to stderr that should give indicators of what
                                is happening.

--- a/flags.go
+++ b/flags.go
@@ -9,6 +9,7 @@ import (
 )
 
 type appFlags struct {
+	noExternals  bool
 	outputFormat *StringEnumValue
 	repoDir      string
 	testDir      string
@@ -31,6 +32,19 @@ func createAndParseFlags(args []string) error {
 		printUsage(fs.FlagUsages())
 	}
 
+	fs.BoolVarP(
+		&flags.noExternals,
+		"no-externals",
+		"n",
+		false,
+		heredoc.Doc(`
+			Disable cloning and processing of external repos. An external repo is
+			one that provides extra functionality to the "newrelic" module. This
+			allows processing a single repo with --repo-dir. The default, i.e. not
+			supplying this flag, is to process all known external repos.
+		`),
+	)
+
 	flags.outputFormat = NewStringEnumValue(
 		[]string{"ascii", "markdown"},
 		"markdown",
@@ -51,10 +65,22 @@ func createAndParseFlags(args []string) error {
 		"r",
 		"",
 		heredoc.Doc(`
-			Specify a local directory that contains a Node.js agent repo.
-			If not provided, the default GitHub repositories will be cloned to a local temporary
-			directory and that will be used.
+			Specify a local directory that contains a Node.js instrumentation repo.
+			If not provided, the main agent GitHub repository will be cloned to a
+			local temporary directory and that will be used.
 		`),
+	)
+
+	fs.StringVarP(
+		&flags.testDir,
+		"test-dir",
+		"t",
+		"",
+		heredoc.Doc(`
+      Specify the test directory to parse the package.json files.
+      If not provided, it will default to 'test/versioned'. This applies to
+			the repo provided by the --repo-dir flag.
+    `),
 	)
 
 	fs.BoolVarP(
@@ -67,17 +93,6 @@ func createAndParseFlags(args []string) error {
 			logs will be written to stderr that should give indicators of what
 			is happening.
 		`),
-	)
-
-	fs.StringVarP(
-		&flags.testDir,
-		"test-dir",
-		"t",
-		"",
-		heredoc.Doc(`
-      Specify the test directory to parse the package.json files.
-      If not provided, it will default to 'test/versioned'.
-    `),
 	)
 
 	// TODO: add flags for generating different formats:

--- a/flags_test.go
+++ b/flags_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+func Test_createAndParseFlags(t *testing.T) {
+	t.Run("defaults are as expected", func(t *testing.T) {
+		err := createAndParseFlags([]string{"ignored"})
+		expected := appFlags{
+			noExternals: false,
+			outputFormat: &StringEnumValue{
+				allowed: []string{"ascii", "markdown"},
+				value:   "markdown",
+			},
+		}
+		assert.Nil(t, err)
+		assert.Equal(t, expected, flags)
+	})
+}
+
 func Test_StringEnumValue(t *testing.T) {
 	t.Run("only allows specified values", func(t *testing.T) {
 		sev := NewStringEnumValue([]string{"foo", "bar"}, "foo")

--- a/types.go
+++ b/types.go
@@ -20,12 +20,6 @@ type dirIterChan struct {
 	err  error
 }
 
-type repoIterChan struct {
-	repoDir  string
-	testPath string
-	err      error
-}
-
 // CloneRepoResult represents the status of Git repository clone operation.
 type CloneRepoResult struct {
 	// Directory is the path on the file system that contains the cloned
@@ -35,6 +29,10 @@ type CloneRepoResult struct {
 	// TestDirectory is a string relative to Directory that contains the
 	// versioned tests for the repository.
 	TestDirectory string
+
+	// Remove indicates if the Directory should be removed after all data
+	// processing has completed.
+	Remove bool
 
 	// Error indicates if there was some problem during the clone operation.
 	// Should be `nil` for success results.


### PR DESCRIPTION
This PR resolves some expectations around `--repo-dir`:

1. The directory specified by `--repo-dir` will not be removed during clean up (burned me 😢)
2. Adds a `--no-externals` flag to skip processing of the predefined external repos (default is to process them)
3. Docs around `--test-dir` updated to make it clear it only applies to the repo provided by `--repo-dir`

The result is that `nrversions -r path/to/repo` will process everything in `path/to/repo` along with the external repos, thus generating the full report. Utilizing `nrversions -r path/to/repo -n` will only process `path/to/repo` if that is needed for some reason.