### PR TITLE
feat: Added switch to render output into a file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,25 +80,33 @@ modules.
 
 The following flags are supported:
 
-  -n, --no-externals           Disable cloning and processing of external repos. An external repo is
-                               one that provides extra functionality to the "newrelic" module. This
-                               allows processing a single repo with --repo-dir. The default, i.e. not
-                               supplying this flag, is to process all known external repos.
-                               
-  -o, --output-format string   Specify the format to write the results as. The default is an ASCII
-                               table. Possible values: "ascii" or "markdown".
-                                (default "markdown")
-  -r, --repo-dir string        Specify a local directory that contains a Node.js instrumentation repo.
-                               If not provided, the main agent GitHub repository will be cloned to a
-                               local temporary directory and that will be used.
-                               
-  -t, --test-dir string        Specify the test directory to parse the package.json files.
-                               If not provided, it will default to 'test/versioned'. This applies to
-                               the repo provided by the --repo-dir flag.
-                                
-  -v, --verbose                Enable verbose output. As the data is being loaded and parsed various
-                               logs will be written to stderr that should give indicators of what
-                               is happening.
+  -n, --no-externals             Disable cloning and processing of external repos. An external repo is
+                                 one that provides extra functionality to the "newrelic" module. This
+                                 allows processing a single repo with --repo-dir. The default, i.e. not
+                                 supplying this flag, is to process all known external repos.
+                                 
+  -o, --output-format string     Specify the format to write the results as. The default is an ASCII
+                                 table. Possible values: "ascii" or "markdown".
+                                  (default "markdown")
+  -R, --replace-in-file string   Specify a target file in which the results will be written. Normally,
+                                 the result is written to stdout. When this flag is given, the result
+                                 will be written to the specified file. The generated text will replace
+                                 all text in the file between two marker lines. The markers can be defined
+                                 through environment variables: START_MARKER and END_MARKER. Default values
+                                 are "{/* begin: compat-table */}"
+                                 and "{/* end: compat-table */}".
+                                 
+  -r, --repo-dir string          Specify a local directory that contains a Node.js instrumentation repo.
+                                 If not provided, the main agent GitHub repository will be cloned to a
+                                 local temporary directory and that will be used.
+                                 
+  -t, --test-dir string          Specify the test directory to parse the package.json files.
+                                 If not provided, it will default to 'test/versioned'. This applies to
+                                 the repo provided by the --repo-dir flag.
+                                  
+  -v, --verbose                  Enable verbose output. As the data is being loaded and parsed various
+                                 logs will be written to stderr that should give indicators of what
+                                 is happening.
 ```
 
 ## Building

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,14 +21,14 @@ tasks:
       - go test ./...
     sources:
       - "**/*.go"
-      - "**/package.json"
+      - "**/testdata/*"
 
   test-cov:
     cmds:
       - go test -cover ./...
     sources:
       - "**/*.go"
-      - "**/package.json"
+      - "**/testdata/*"
 
   test-cov-html:
     cmds:
@@ -36,4 +36,4 @@ tasks:
       - go tool cover -html=./coverage.out -o ./coverage.html
     sources:
       - "**/*.go"
-      - "**/package.json"
+      - "**/testdata/*"

--- a/flags_test.go
+++ b/flags_test.go
@@ -14,6 +14,8 @@ func Test_createAndParseFlags(t *testing.T) {
 				allowed: []string{"ascii", "markdown"},
 				value:   "markdown",
 			},
+			startMarker: "{/* begin: compat-table */}",
+			endMarker:   "{/* end: compat-table */}",
 		}
 		assert.Nil(t, err)
 		assert.Equal(t, expected, flags)

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 
+	_ "embed"
+
 	"blitznote.com/src/semver/v3"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/go-git/go-git/v5"
@@ -23,6 +25,9 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+//go:embed tmpl/preamble.md
+var docPreamble string
+
 var agentRepo = nrRepo{url: `https://github.com/newrelic/node-newrelic.git`, branch: `main`, testPath: `test/versioned`}
 var externalsRepos = []nrRepo{
 	{url: `https://github.com/newrelic/newrelic-node-apollo-server-plugin.git`, branch: `main`, testPath: `tests/versioned`},
@@ -30,10 +35,10 @@ var externalsRepos = []nrRepo{
 }
 
 var columHeaders = map[string]string{
-	"Name":                `Package Name`,
-	"MinSupportedVersion": `Minimum Supported Version`,
-	"LatestVersion":       `Latest Supported Version`,
-	"MinAgentVersion":     `Introduced In*`,
+	"Name":                `Package name`,
+	"MinSupportedVersion": `Minimum supported version`,
+	"LatestVersion":       `Latest supported version`,
+	"MinAgentVersion":     `Introduced in*`,
 }
 
 var appFS = afero.NewOsFs()
@@ -422,17 +427,7 @@ func renderAsAscii(data []ReleaseData, writer io.Writer) {
 // email it to a customer).
 func renderAsMarkdown(data []ReleaseData, writer io.Writer) {
 	outputTable := releaseDataToTable(data)
-	io.WriteString(
-		writer,
-		heredoc.Doc(`
-			## Instrumented Modules
-
-			After installation, the agent automatically instruments with our catalog of supported Node.js libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers.  For unsupported frameworks or libraries, you'll need to instrument the agent yourself using the [Node.js agent API](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
-
-			**Note**: The latest supported version may not reflect the most recent supported version.
-
-		`),
-	)
+	io.WriteString(writer, docPreamble)
 	io.WriteString(writer, "\n")
 	io.WriteString(writer, outputTable.RenderMarkdown())
 	io.WriteString(writer, "\n\n")

--- a/main.go
+++ b/main.go
@@ -461,7 +461,13 @@ func releaseDataToTable(data []ReleaseData) table.Writer {
 		row := table.Row{}
 		rv = reflect.ValueOf(info)
 		for _, key := range keys {
-			row = append(row, rv.FieldByName(key).Interface())
+			value := rv.FieldByName(key).Interface().(string)
+			if key == "Name" {
+				value = fmt.Sprintf("`%s`", value)
+			} else if key == "MinAgentVersion" && strings.HasPrefix(value, "@") == true {
+				value = fmt.Sprintf("`%s`", value)
+			}
+			row = append(row, value)
 		}
 		outputTable.AppendRow(row)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -292,3 +292,29 @@ func Test_pruneData(t *testing.T) {
 	}
 	assert.Equal(t, expected, pruneData(input))
 }
+
+func Test_releaseDataToTable(t *testing.T) {
+	input := []ReleaseData{
+		{
+			Name:                       "foo",
+			MinSupportedVersion:        "1.0.0",
+			MinSupportedVersionRelease: "2023-05-21",
+			LatestVersion:              "2.0.0",
+			LatestVersionRelease:       "2024-05-21",
+			MinAgentVersion:            "2.0.0",
+		},
+		{
+			Name:                       "@foo/bar",
+			MinSupportedVersion:        "1.0.0",
+			MinSupportedVersionRelease: "2023-05-21",
+			LatestVersion:              "2.0.0",
+			LatestVersionRelease:       "2024-05-21",
+			MinAgentVersion:            "@newrelic/foo-bar@1.0.0",
+		},
+	}
+	expected, err := os.ReadFile("testdata/data-table.expected.md")
+	require.Nil(t, err)
+
+	found := releaseDataToTable(input)
+	assert.Equal(t, expected, []byte(found.RenderMarkdown()+"\n"))
+}

--- a/replace-into.go
+++ b/replace-into.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
+type fileParts struct {
+	head []byte
+	tail []byte
+}
+
+// ReplaceInFile writes the provided content in the specified file by replacing
+// any existing content between two markers.
+func ReplaceInFile(
+	file string,
+	content string,
+	startMarker string,
+	endMarker string,
+) error {
+	fp, err := appFS.OpenFile(file, os.O_RDWR, 0666)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	parts, err := getParts(fp, startMarker, endMarker)
+	if err != nil {
+		return err
+	}
+
+	_, err = fp.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	err = fp.Truncate(0)
+	if err != nil {
+		return err
+	}
+
+	doc := [][]byte{
+		parts.head,
+		[]byte(startMarker + "\n"),
+		[]byte(content),
+		[]byte("\n" + endMarker),
+		parts.tail,
+	}
+	err = writeDoc(fp, doc)
+
+	return err
+}
+
+// getParts splits a file into the header and tail parts denoted by the given
+// markers.
+func getParts(reader io.Reader, startMarker string, endMarker string) (*fileParts, error) {
+	fileContents, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytes.Index(fileContents, []byte(startMarker)) == -1 {
+		return nil, fmt.Errorf("unable to find start marker: `%s`", startMarker)
+	}
+	if bytes.Index(fileContents, []byte(endMarker)) == -1 {
+		return nil, fmt.Errorf("unable to find end marker: `%s`", endMarker)
+	}
+
+	result := &fileParts{}
+	parts := bytes.Split(fileContents, []byte(startMarker))
+	result.head = parts[0]
+
+	parts = bytes.Split(fileContents, []byte(endMarker))
+	result.tail = parts[1]
+
+	return result, nil
+}
+
+// writeDoc writes out the parts of a document into the provided
+// writer.
+func writeDoc(writer io.Writer, parts [][]byte) error {
+	_, err := writer.Write(bytes.Join(parts, []byte("")))
+	return err
+}

--- a/replace-into_test.go
+++ b/replace-into_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"strings"
+	"testing"
+)
+
+// errorWriter is an [io.Writer] that always returns an error
+// when attempting to write data.
+type errorWriter struct{}
+
+func (ew *errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func Test_ReplaceInFile(t *testing.T) {
+	origFS := appFS
+	t.Cleanup(func() {
+		appFS = origFS
+	})
+
+	inputFileContent, e := os.ReadFile("testdata/replace-into.input.md")
+	require.Nil(t, e)
+	expectedFileContent, e := os.ReadFile("testdata/replace-into.expected.md")
+	require.Nil(t, e)
+
+	t.Run("returns error if file cannot be opened", func(t *testing.T) {
+		appFS = afero.NewMemMapFs()
+		err := ReplaceInFile("foo.md", "bar", "a", "b")
+		assert.ErrorContains(t, err, "file does not exist")
+	})
+
+	t.Run("replaces as expected", func(t *testing.T) {
+		appFS = afero.NewMemMapFs()
+		err := afero.WriteFile(appFS, "foo.md", inputFileContent, 0o777)
+		require.Nil(t, err)
+		appFS.Chmod("foo.md", os.ModePerm)
+
+		err = ReplaceInFile(
+			"foo.md",
+			"\nfoobar\n",
+			"{/* begin: compat-table */}",
+			"{/* end: compat-table */}",
+		)
+		assert.Nil(t, err)
+
+		found, err := afero.ReadFile(appFS, "foo.md")
+		assert.Equal(t, expectedFileContent, found)
+	})
+}
+
+func Test_getParts(t *testing.T) {
+	t.Run("returns error for bad read", func(t *testing.T) {
+		found, err := getParts(&errorReader{}, "a", "b")
+		assert.Nil(t, found)
+		assert.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("returns error if cannot find start marker", func(t *testing.T) {
+		reader := strings.NewReader("foo bar")
+		found, err := getParts(reader, "~~~", "---")
+		assert.Nil(t, found)
+		assert.ErrorContains(t, err, "unable to find start marker: `~~~`")
+	})
+
+	t.Run("returns error if cannot find end marker", func(t *testing.T) {
+		reader := strings.NewReader("foo ~~~ bar")
+		found, err := getParts(reader, "~~~", "---")
+		assert.Nil(t, found)
+		assert.ErrorContains(t, err, "unable to find end marker: `---`")
+	})
+
+	t.Run("splits into parts correctly", func(t *testing.T) {
+		doc := []string{
+			"header line 1",
+			"",
+			"header line 3",
+			"",
+			"{start_marker}",
+			"replace me",
+			"",
+			"{end_marker}",
+			"",
+			"tail line 1",
+		}
+		input := strings.Join(doc, "\n")
+		expected := &fileParts{
+			// TODO: there's a bug in strings.Join that is skipping the final ""
+			//head: []byte(strings.Join(doc[0:4], "\n")),
+			head: []byte("header line 1\n\nheader line 3\n\n"),
+			//tail: []byte(strings.Join(doc[8:], "\n")),
+			tail: []byte("\n\ntail line 1"),
+		}
+
+		found, err := getParts(strings.NewReader(input), "{start_marker}", "{end_marker}")
+		assert.Nil(t, err)
+		assert.Equal(t, expected, found)
+	})
+}
+
+func Test_writeDoc(t *testing.T) {
+	t.Run("returns error for bad write", func(t *testing.T) {
+		writer := &errorWriter{}
+		err := writeDoc(writer, [][]byte{})
+		assert.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("writes a doc", func(t *testing.T) {
+		writer := &bytes.Buffer{}
+		input := [][]byte{
+			[]byte("foo"),
+			[]byte("bar"),
+		}
+		expected := []byte("foobar")
+		err := writeDoc(writer, input)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, writer.Bytes())
+	})
+}

--- a/testdata/data-table.expected.md
+++ b/testdata/data-table.expected.md
@@ -1,0 +1,4 @@
+| Package name | Minimum supported version | Latest supported version | Introduced in* |
+| --- | --- | --- | --- |
+| `foo` | 1.0.0 | 2.0.0 | 2.0.0 |
+| `@foo/bar` | 1.0.0 | 2.0.0 | `@newrelic/foo-bar@1.0.0` |

--- a/testdata/replace-into.expected.md
+++ b/testdata/replace-into.expected.md
@@ -1,0 +1,9 @@
+This file is an input file for `--replace-in-file` testing.
+
+{/* begin: compat-table */}
+
+foobar
+
+{/* end: compat-table */}
+
+The end.

--- a/testdata/replace-into.input.md
+++ b/testdata/replace-into.input.md
@@ -1,0 +1,11 @@
+This file is an input file for `--replace-in-file` testing.
+
+{/* begin: compat-table */}
+
+This will be replaced.
+
+This will be replaced.
+
+{/* end: compat-table */}
+
+The end.

--- a/tmpl/preamble.md
+++ b/tmpl/preamble.md
@@ -4,7 +4,7 @@ After installation, the agent automatically instruments with our catalog of
 supported Node.js libraries and frameworks. This gives you immediate access to
 granular information specific to your web apps and servers.  For unsupported
 frameworks or libraries, you'll need to instrument the agent yourself using the
-[Node.js agent API](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
+[Node.js agent API](https://newrelic.github.io/node-newrelic/API.html).
 
 **Note**: The latest supported version may not reflect the most recent supported
 version.

--- a/tmpl/preamble.md
+++ b/tmpl/preamble.md
@@ -1,0 +1,10 @@
+## Instrumented modules
+
+After installation, the agent automatically instruments with our catalog of
+supported Node.js libraries and frameworks. This gives you immediate access to
+granular information specific to your web apps and servers.  For unsupported
+frameworks or libraries, you'll need to instrument the agent yourself using the
+[Node.js agent API](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
+
+**Note**: The latest supported version may not reflect the most recent supported
+version.


### PR DESCRIPTION
This PR adds tooling to render the output into a section of a file delimited by start and end markers. This will make it easier to generate the pull requests for updating the docs site. I went with this method because utilizing common tooling to inject the regular stdout proved difficult. Basically, because the target file is an "mdx" file, and those files only support comments like `{/* this is a comment */}`, it makes crafting a `sed` script very tricky (`{`, `\{`, `*`, and `\*` all have significance in `sed`). Also, this route gives us testable code.