### PR TITLE
feat: Added rendering of our AI Monitoring compatibilities

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,50 +24,8 @@ This project relies on some community tools that require extra installation:
 ./nrversions
 ```
 
-Will output a compatibility report like this
-
-```
-+------------------------+---------------------+----------------------------+---------------+----------------------+
-| NAME                   | MINSUPPORTEDVERSION | MINSUPPORTEDVERSIONRELEASE | LATESTVERSION | LATESTVERSIONRELEASE |
-+------------------------+---------------------+----------------------------+---------------+----------------------+
-| @apollo/gateway        | 2.3.0               | 2023-01-25                 | 2.7.3         | 2024-04-16           |
-| @apollo/server         | 4.0.0               | 2022-10-10                 | 4.10.3        | 2024-04-15           |
-| @elastic/elasticsearch | 7.16.0              | 2021-12-15                 | 8.13.1        | 2024-04-09           |
-| @grpc/grpc-js          | 1.4.0               | 2021-10-13                 | 1.10.6        | 2024-04-03           |
-| @hapi/hapi             | 20.1.2              | 2021-03-20                 | 21.3.9        | 2024-04-09           |
-| @langchain/core        | 0.1.17              | 2024-01-19                 | 0.1.58        | 2024-04-16           |
-| @nestjs/cli            | 8.0.0               | 2021-07-07                 | 10.3.2        | 2024-02-07           |
-| @prisma/client         | 5.0.0               | 2023-07-11                 | 5.12.1        | 2024-04-04           |
-| amqplib                | 0.5.0               | 2016-11-01                 | 0.10.4        | 2024-04-11           |
-| apollo-server          | 2.14.0              | 2020-05-27                 | 3.13.0        | 2023-11-14           |
-| apollo-server-express  | 2.14.0              | 2020-05-27                 | 3.13.0        | 2023-11-14           |
-| apollo-server-fastify  | 2.14.0              | 2020-05-27                 | 3.13.0        | 2023-11-14           |
-| apollo-server-hapi     | 3.0.0               | 2021-07-07                 | 3.13.0        | 2023-11-14           |
-| apollo-server-koa      | 2.14.0              | 2020-05-27                 | 3.13.0        | 2023-11-14           |
-| apollo-server-lambda   | 2.14.0              | 2020-05-27                 | 3.13.0        | 2023-11-14           |
-| bluebird               | 2.0.0               | 2014-06-04                 | 3.7.2         | 2019-11-28           |
-| bunyan                 | 1.8.12              | 2017-08-02                 | 1.8.15        | 2021-01-08           |
-| cassandra-driver       | 3.4.0               | 2018-02-05                 | 4.7.2         | 2023-09-21           |
-| connect                | 2.0.0               | 2012-02-28                 | 3.7.0         | 2019-05-18           |
-| director               | 1.2.0               | 2013-04-01                 | 1.2.8         | 2015-02-04           |
-| express                | 4.6.0               | 2014-07-12                 | 4.19.2        | 2024-03-25           |
-| fastify                | 2.0.0               | 2019-02-25                 | 4.26.2        | 2024-03-03           |
-| generic-pool           | 2.4.0               | 2016-01-18                 | 3.9.0         | 2022-09-10           |
-| ioredis                | 3.0.0               | 2017-05-18                 | 5.3.2         | 2023-04-15           |
-| mongodb                | 2.1.0               | 2015-12-06                 | 6.5.0         | 2024-03-11           |
-| mysql                  | 2.2.0               | 2014-04-27                 | 2.18.1        | 2020-01-23           |
-| mysql2                 | 1.3.1               | 2017-05-31                 | 3.9.4         | 2024-04-09           |
-| next                   | 13.0.0              | 2022-10-25                 | 14.2.1        | 2024-04-12           |
-| openai                 | 4.0.0               | 2023-08-16                 | 4.35.0        | 2024-04-16           |
-| pg                     | 8.2.0               | 2020-05-13                 | 8.11.5        | 2024-04-02           |
-| pino                   | 7.0.0               | 2021-10-14                 | 8.20.0        | 2024-04-06           |
-| redis                  | 2.0.0               | 2015-09-21                 | 4.6.13        | 2024-02-05           |
-| restify                | 5.0.0               | 2017-06-27                 | 11.1.0        | 2023-02-24           |
-| superagent             | 2.0.0               | 2016-05-29                 | 8.1.2         | 2023-08-15           |
-| undici                 | 4.7.0               | 2021-09-22                 | 6.13.0        | 2024-04-12           |
-| winston                | 3.0.0               | 2018-06-12                 | 3.13.0        | 2024-03-24           |
-+------------------------+---------------------+----------------------------+---------------+----------------------+
-```
+Will output a report document as shown in our main repo's
+[compatibility doc](https://github.com/newrelic/node-newrelic/blob/main/compatibility.md).
 
 For optional CLI args, run:
 
@@ -80,14 +38,15 @@ modules.
 
 The following flags are supported:
 
+  -a, --ai-compat-json string    Path to the ai-compat.json file that describes the AI Monitoring
+                                 compatibility of the agent. The default is to use the JSON file included
+                                 in the mainline agent repository.
+                                 
   -n, --no-externals             Disable cloning and processing of external repos. An external repo is
                                  one that provides extra functionality to the "newrelic" module. This
                                  allows processing a single repo with --repo-dir. The default, i.e. not
                                  supplying this flag, is to process all known external repos.
                                  
-  -o, --output-format string     Specify the format to write the results as. The default is an ASCII
-                                 table. Possible values: "ascii" or "markdown".
-                                  (default "markdown")
   -R, --replace-in-file string   Specify a target file in which the results will be written. Normally,
                                  the result is written to stdout. When this flag is given, the result
                                  will be written to the specified file. The generated text will replace

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,7 @@ tasks:
     sources:
       - "**/*.go"
       - "**/testdata/*"
+      - "**/tmpl/*"
 
   test-cov:
     cmds:
@@ -29,6 +30,7 @@ tasks:
     sources:
       - "**/*.go"
       - "**/testdata/*"
+      - "**/tmpl/*"
 
   test-cov-html:
     cmds:
@@ -37,3 +39,4 @@ tasks:
     sources:
       - "**/*.go"
       - "**/testdata/*"
+      - "**/tmpl/*"

--- a/ai-compat-types.go
+++ b/ai-compat-types.go
@@ -6,25 +6,31 @@ const AiCompatKindSdk = "sdk"
 
 type AiCompatJson []AiCompatEnvelope
 
+// AiCompatEnvelope represents the generic structure of objects found within
+// the AI compatability JSON descriptor document.
 type AiCompatEnvelope struct {
 	Kind              string             `json:"kind"`
 	Title             string             `json:"title"`
-	Preamble          string             `json:"preamble"`
-	Footnote          string             `json:"footnote"`
-	FeaturesPreamble  string             `json:"featuresPreamble"`
-	ProvidersPreamble string             `json:"providersPreamble"`
+	Preamble          string             `json:"preamble,omitempty"`
+	Footnote          string             `json:"footnote,omitempty"`
+	FeaturesPreamble  string             `json:"featuresPreamble,omitempty"`
+	ProvidersPreamble string             `json:"providersPreamble,omitempty"`
 	Models            []AiCompatModel    `json:"models,omitempty"`
 	Features          []AiCompatFeature  `json:"features,omitempty"`
 	Providers         []AiCompatProvider `json:"providers,omitempty"`
 }
 
+// AiCompatGateway is a narrow type derived from an [AiCompatEnvelope] with
+// `kind = "gateway"`.
 type AiCompatGateway struct {
 	Title    string
 	Preamble string
 	Footnote string
-	Models   []AiCompatGatewayModel
+	Models   []AiCompatModel
 }
 
+// AiCompatAbstraction is a narrow type derived from an [AiCompatEnvelope] with
+// `kind = "abstraction"`.
 type AiCompatAbstraction struct {
 	Title             string
 	FeaturesPreamble  string
@@ -33,9 +39,12 @@ type AiCompatAbstraction struct {
 	Providers         []AiCompatProvider
 }
 
-type AiCompatGatewayModel struct {
-	Title    string
-	Features []AiCompatFeature
+// AiCompatSdk is a narrow type derived from an [AiCompatEnvelope] with
+// `kind = "sdk"`.
+type AiCompatSdk struct {
+	Title            string
+	FeaturesPreamble string
+	Features         []AiCompatFeature
 }
 
 type AiCompatFeature struct {
@@ -54,43 +63,10 @@ type AiCompatProvider struct {
 	Transitively bool   `json:"transitively"`
 }
 
+// AiCompatTemplateData represents the context that will be utilized by the
+// template engine to render the human readable Markdown document.
 type AiCompatTemplateData struct {
 	Abstractions []AiCompatAbstraction
 	Gateways     []AiCompatGateway
-	Bedrock      AiCompatBedrockData
-	Langchain    AiCompatLangchainData
-	Openai       AiCompatOpenaiData
-}
-
-type AiCompatBedrockData struct {
-	Title  string
-	Models []struct {
-		Name  string
-		Text  bool
-		Image bool
-	}
-}
-
-type AiCompatLangchainData struct {
-	Title    string
-	Features struct {
-		Agents       bool
-		Chains       bool
-		Vectorstores bool
-		Tools        bool
-	}
-	Providers []struct {
-		Name         string
-		Supported    bool
-		Transitively bool
-	}
-}
-
-type AiCompatOpenaiData struct {
-	Completions bool
-	Chat        bool
-	Embeddings  bool
-	Files       bool
-	Images      bool
-	Audio       bool
+	Sdks         []AiCompatSdk
 }

--- a/ai-compat-types.go
+++ b/ai-compat-types.go
@@ -9,9 +9,23 @@ type AiCompatJson []AiCompatEnvelope
 type AiCompatEnvelope struct {
 	Kind      string             `json:"kind"`
 	Title     string             `json:"title"`
+	Preamble  string             `json:"preamble"`
+	Footnote  string             `json:"footnote"`
 	Models    []AiCompatModel    `json:"models,omitempty"`
 	Features  []AiCompatFeature  `json:"features,omitempty"`
 	Providers []AiCompatProvider `json:"providers,omitempty"`
+}
+
+type AiCompatGateway struct {
+	Title    string
+	Preamble string
+	Footnote string
+	Models   []AiCompatGatewayModel
+}
+
+type AiCompatGatewayModel struct {
+	Title    string
+	Features []AiCompatFeature
 }
 
 type AiCompatFeature struct {
@@ -31,6 +45,7 @@ type AiCompatProvider struct {
 }
 
 type AiCompatTemplateData struct {
+	Gateways  []AiCompatGateway
 	Bedrock   AiCompatBedrockData
 	Langchain AiCompatLangchainData
 	Openai    AiCompatOpenaiData

--- a/ai-compat-types.go
+++ b/ai-compat-types.go
@@ -7,13 +7,15 @@ const AiCompatKindSdk = "sdk"
 type AiCompatJson []AiCompatEnvelope
 
 type AiCompatEnvelope struct {
-	Kind      string             `json:"kind"`
-	Title     string             `json:"title"`
-	Preamble  string             `json:"preamble"`
-	Footnote  string             `json:"footnote"`
-	Models    []AiCompatModel    `json:"models,omitempty"`
-	Features  []AiCompatFeature  `json:"features,omitempty"`
-	Providers []AiCompatProvider `json:"providers,omitempty"`
+	Kind              string             `json:"kind"`
+	Title             string             `json:"title"`
+	Preamble          string             `json:"preamble"`
+	Footnote          string             `json:"footnote"`
+	FeaturesPreamble  string             `json:"featuresPreamble"`
+	ProvidersPreamble string             `json:"providersPreamble"`
+	Models            []AiCompatModel    `json:"models,omitempty"`
+	Features          []AiCompatFeature  `json:"features,omitempty"`
+	Providers         []AiCompatProvider `json:"providers,omitempty"`
 }
 
 type AiCompatGateway struct {
@@ -21,6 +23,14 @@ type AiCompatGateway struct {
 	Preamble string
 	Footnote string
 	Models   []AiCompatGatewayModel
+}
+
+type AiCompatAbstraction struct {
+	Title             string
+	FeaturesPreamble  string
+	ProvidersPreamble string
+	Features          []AiCompatFeature
+	Providers         []AiCompatProvider
 }
 
 type AiCompatGatewayModel struct {
@@ -45,10 +55,11 @@ type AiCompatProvider struct {
 }
 
 type AiCompatTemplateData struct {
-	Gateways  []AiCompatGateway
-	Bedrock   AiCompatBedrockData
-	Langchain AiCompatLangchainData
-	Openai    AiCompatOpenaiData
+	Abstractions []AiCompatAbstraction
+	Gateways     []AiCompatGateway
+	Bedrock      AiCompatBedrockData
+	Langchain    AiCompatLangchainData
+	Openai       AiCompatOpenaiData
 }
 
 type AiCompatBedrockData struct {

--- a/ai-compat-types.go
+++ b/ai-compat-types.go
@@ -1,0 +1,70 @@
+package main
+
+const AiCompatKindGateway = "gateway"
+const AiCompatKindAbstraction = "abstraction"
+const AiCompatKindSdk = "sdk"
+
+type AiCompatJson []AiCompatEnvelope
+
+type AiCompatEnvelope struct {
+	Kind      string             `json:"kind"`
+	Title     string             `json:"title"`
+	Models    []AiCompatModel    `json:"models,omitempty"`
+	Features  []AiCompatFeature  `json:"features,omitempty"`
+	Providers []AiCompatProvider `json:"providers,omitempty"`
+}
+
+type AiCompatFeature struct {
+	Title     string `json:"title"`
+	Supported bool   `json:"supported"`
+}
+
+type AiCompatModel struct {
+	Name     string            `json:"name"`
+	Features []AiCompatFeature `json:"features"`
+}
+
+type AiCompatProvider struct {
+	Name         string `json:"name"`
+	Supported    bool   `json:"supported"`
+	Transitively bool   `json:"transitively"`
+}
+
+type AiCompatTemplateData struct {
+	Bedrock   AiCompatBedrockData
+	Langchain AiCompatLangchainData
+	Openai    AiCompatOpenaiData
+}
+
+type AiCompatBedrockData struct {
+	Title  string
+	Models []struct {
+		Name  string
+		Text  bool
+		Image bool
+	}
+}
+
+type AiCompatLangchainData struct {
+	Title    string
+	Features struct {
+		Agents       bool
+		Chains       bool
+		Vectorstores bool
+		Tools        bool
+	}
+	Providers []struct {
+		Name         string
+		Supported    bool
+		Transitively bool
+	}
+}
+
+type AiCompatOpenaiData struct {
+	Completions bool
+	Chat        bool
+	Embeddings  bool
+	Files       bool
+	Images      bool
+	Audio       bool
+}

--- a/ai-compat-types_test.go
+++ b/ai-compat-types_test.go
@@ -60,8 +60,9 @@ func Test_AiCompatJson(t *testing.T) {
 	assert.Equal(t, expectedAbstraction, parsed[2])
 
 	expectedSdk := AiCompatEnvelope{
-		Kind:  AiCompatKindSdk,
-		Title: "OpenAI",
+		Kind:             AiCompatKindSdk,
+		Title:            "OpenAI",
+		FeaturesPreamble: "Through the `openai` module, we support:",
 		Features: []AiCompatFeature{
 			{"Completions", true},
 			{"Chat", true},

--- a/ai-compat-types_test.go
+++ b/ai-compat-types_test.go
@@ -15,11 +15,13 @@ func Test_AiCompatJson(t *testing.T) {
 	var parsed AiCompatJson
 	err = json.Unmarshal(fileData, &parsed)
 	require.Nil(t, err)
-	assert.Equal(t, 3, len(parsed))
+	assert.Equal(t, 4, len(parsed))
 
 	expectedGateway := AiCompatEnvelope{
-		Kind:  AiCompatKindGateway,
-		Title: "Amazon Bedrock",
+		Kind:     AiCompatKindGateway,
+		Title:    "Amazon Bedrock",
+		Preamble: "Through the `@aws-sdk/client-bedrock-runtime` module, we support:",
+		Footnote: "Note: if a model supports streaming, we also instrument the streaming variant.",
 		Models: []AiCompatModel{
 			{
 				Name: "Claude",
@@ -53,7 +55,7 @@ func Test_AiCompatJson(t *testing.T) {
 			{"OpenAI", true, true},
 		},
 	}
-	assert.Equal(t, expectedAbstraction, parsed[1])
+	assert.Equal(t, expectedAbstraction, parsed[2])
 
 	expectedSdk := AiCompatEnvelope{
 		Kind:  AiCompatKindSdk,
@@ -67,5 +69,5 @@ func Test_AiCompatJson(t *testing.T) {
 			{"Audio", false},
 		},
 	}
-	assert.Equal(t, expectedSdk, parsed[2])
+	assert.Equal(t, expectedSdk, parsed[3])
 }

--- a/ai-compat-types_test.go
+++ b/ai-compat-types_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func Test_AiCompatJson(t *testing.T) {
+	fileData, err := os.ReadFile("testdata/ai-compat.json")
+	require.Nil(t, err)
+
+	var parsed AiCompatJson
+	err = json.Unmarshal(fileData, &parsed)
+	require.Nil(t, err)
+	assert.Equal(t, 3, len(parsed))
+
+	expectedGateway := AiCompatEnvelope{
+		Kind:  AiCompatKindGateway,
+		Title: "Amazon Bedrock",
+		Models: []AiCompatModel{
+			{
+				Name: "Claude",
+				Features: []AiCompatFeature{
+					{"Text", true},
+					{"Image", false},
+				},
+			},
+			{
+				Name: "Cohere",
+				Features: []AiCompatFeature{
+					{"Text", true},
+					{"Image", false},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expectedGateway, parsed[0])
+
+	expectedAbstraction := AiCompatEnvelope{
+		Kind:  AiCompatKindAbstraction,
+		Title: "Langchain",
+		Features: []AiCompatFeature{
+			{"Agents", true},
+			{"Chains", true},
+			{"Vectorstores", true},
+			{"Tools", true},
+		},
+		Providers: []AiCompatProvider{
+			{"Azure OpenAI", false, false},
+			{"OpenAI", true, true},
+		},
+	}
+	assert.Equal(t, expectedAbstraction, parsed[1])
+
+	expectedSdk := AiCompatEnvelope{
+		Kind:  AiCompatKindSdk,
+		Title: "OpenAI",
+		Features: []AiCompatFeature{
+			{"Completions", true},
+			{"Chat", true},
+			{"Embeddings", true},
+			{"Files", false},
+			{"Images", false},
+			{"Audio", false},
+		},
+	}
+	assert.Equal(t, expectedSdk, parsed[2])
+}

--- a/ai-compat-types_test.go
+++ b/ai-compat-types_test.go
@@ -42,8 +42,10 @@ func Test_AiCompatJson(t *testing.T) {
 	assert.Equal(t, expectedGateway, parsed[0])
 
 	expectedAbstraction := AiCompatEnvelope{
-		Kind:  AiCompatKindAbstraction,
-		Title: "Langchain",
+		Kind:              AiCompatKindAbstraction,
+		Title:             "Langchain",
+		FeaturesPreamble:  "The following general features of Langchain are supported:",
+		ProvidersPreamble: "Models/providers are generally supported transitively by our instrumentation of the provider's module.",
 		Features: []AiCompatFeature{
 			{"Agents", true},
 			{"Chains", true},

--- a/ai-monitoring-tmpl.go
+++ b/ai-monitoring-tmpl.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+)
+
+//go:embed tmpl/ai-monitoring-support.md
+var aiMonitoringTmplString string
+
+// RenderAiCompatDoc renders the specified AI Monitoring support JSON
+// descriptor file into Markdown text that is readable and understandable (🤞)
+// by humans.
+func RenderAiCompatDoc(descriptorJsonFile string, writer io.Writer) error {
+	reader, err := appFS.Open(descriptorJsonFile)
+	if err != nil {
+		return fmt.Errorf("could not read descriptor json file: %w", err)
+	}
+
+	parsedJson, err := aiCompatReadJson(reader)
+	if err != nil {
+		return fmt.Errorf("could not parse descriptor json file: %w", err)
+	}
+
+	tmpl, err := aiCompatLoadTemplate()
+	if err != nil {
+		return fmt.Errorf("could not load template: %w", err)
+	}
+
+	tmplData := aiCompatBuildTmplData(parsedJson)
+	err = tmpl.Execute(writer, tmplData)
+	if err != nil {
+		return fmt.Errorf("failed to render template: %w", err)
+	}
+
+	return nil
+}
+
+func aiCompatReadJson(file io.Reader) (AiCompatJson, error) {
+	var result AiCompatJson
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read json from file reader: %w", err)
+	}
+	err = json.Unmarshal(data, &result)
+	return result, err
+}
+
+func aiCompatBuildTmplData(input AiCompatJson) AiCompatTemplateData {
+	result := AiCompatTemplateData{}
+
+	for _, envelope := range input {
+		switch strings.ToLower(envelope.Kind) {
+		case AiCompatKindGateway:
+			result.Bedrock = aiCompatParseBedrockData(envelope)
+		case AiCompatKindAbstraction:
+			result.Langchain = aiCompatParseLangchainData(envelope)
+		case AiCompatKindSdk:
+			result.Openai = aiCompatParseOpenaiData(envelope)
+		}
+	}
+
+	return result
+}
+
+func aiCompatLoadTemplate() (*template.Template, error) {
+	tmpl := template.New("aiMonitoring")
+
+	tmpl.Funcs(template.FuncMap{
+		"boolEmoji": aiCompatBoolEmoji,
+	})
+
+	tmpl, err := tmpl.Parse(aiMonitoringTmplString)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpl, nil
+}
+
+func aiCompatParseBedrockData(envelope AiCompatEnvelope) AiCompatBedrockData {
+	result := AiCompatBedrockData{Title: envelope.Title}
+
+	result.Models = make([]struct {
+		Name  string
+		Text  bool
+		Image bool
+	}, 0)
+	for _, model := range envelope.Models {
+		modelData := struct {
+			Name  string
+			Text  bool
+			Image bool
+		}{}
+		modelData.Name = model.Name
+		for _, feature := range model.Features {
+			if strings.ToLower(feature.Title) == "text" {
+				modelData.Text = feature.Supported
+			}
+			if strings.ToLower(feature.Title) == "Image" {
+				modelData.Image = feature.Supported
+			}
+		}
+		result.Models = append(result.Models, modelData)
+	}
+
+	return result
+}
+
+func aiCompatParseLangchainData(envelope AiCompatEnvelope) AiCompatLangchainData {
+	result := AiCompatLangchainData{Title: envelope.Title}
+
+	result.Features = struct {
+		Agents       bool
+		Chains       bool
+		Vectorstores bool
+		Tools        bool
+	}{}
+	for _, feature := range envelope.Features {
+		switch strings.ToLower(feature.Title) {
+		case "agents":
+			result.Features.Agents = feature.Supported
+		case "chains":
+			result.Features.Chains = feature.Supported
+		case "vectorstores":
+			result.Features.Vectorstores = feature.Supported
+		case "Tools":
+			result.Features.Tools = feature.Supported
+		}
+	}
+
+	result.Providers = make([]struct {
+		Name         string
+		Supported    bool
+		Transitively bool
+	}, 0)
+	for _, provider := range envelope.Providers {
+		providerData := struct {
+			Name         string
+			Supported    bool
+			Transitively bool
+		}{provider.Name, provider.Supported, provider.Transitively}
+		result.Providers = append(result.Providers, providerData)
+	}
+
+	return result
+}
+
+func aiCompatParseOpenaiData(envelope AiCompatEnvelope) AiCompatOpenaiData {
+	result := AiCompatOpenaiData{}
+
+	for _, feature := range envelope.Features {
+		switch strings.ToLower(feature.Title) {
+		case "completions":
+			result.Completions = feature.Supported
+		case "chat":
+			result.Chat = feature.Supported
+		case "embeddings":
+			result.Embeddings = feature.Supported
+		case "files":
+			result.Files = feature.Supported
+		case "images":
+			result.Images = feature.Supported
+		case "audio":
+			result.Audio = feature.Supported
+		}
+	}
+
+	return result
+}
+
+// aiCompatBoolEmoji converts a boolean into emoji text representing the
+// respective value. It is added to the AI compat document template as a
+// convenience method so that if/else blocks do not need to be repeated
+// throughout the template source.
+func aiCompatBoolEmoji(input bool) string {
+	if input == true {
+		return "✅"
+	}
+	return "❌"
+}

--- a/ai-monitoring-tmpl_test.go
+++ b/ai-monitoring-tmpl_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_RenderAiCompatDoc(t *testing.T) {
+	t.Run("successfully renders document", func(t *testing.T) {
+		expected, err := os.ReadFile("testdata/ai-compat.expected.md")
+		require.Nil(t, err)
+
+		builder := strings.Builder{}
+		err = RenderAiCompatDoc("testdata/ai-compat.json", &builder)
+		assert.Nil(t, err)
+
+		assert.Equal(t, string(expected), builder.String())
+	})
+
+	t.Run("errors if cannot open json file", func(t *testing.T) {
+		err := RenderAiCompatDoc("testdata/bad-file.does.not.exist", io.Discard)
+		assert.ErrorContains(t, err, "could not read descriptor json file")
+	})
+
+	t.Run("errors if json is bad", func(t *testing.T) {
+		currFS := appFS
+		t.Cleanup(func() {
+			appFS = currFS
+		})
+
+		appFS = afero.NewMemMapFs()
+		file, err := appFS.Create("foo.json")
+		require.Nil(t, err)
+		io.WriteString(file, `{"bad":json`)
+
+		err = RenderAiCompatDoc("foo.json", io.Discard)
+		assert.ErrorContains(t, err, "could not parse descriptor json file")
+	})
+
+	t.Run("errors if template is invalid", func(t *testing.T) {
+		curTmplString := aiMonitoringTmplString
+		t.Cleanup(func() {
+			aiMonitoringTmplString = curTmplString
+		})
+		aiMonitoringTmplString = "{{bad}"
+
+		err := RenderAiCompatDoc("testdata/ai-compat.json", io.Discard)
+		assert.ErrorContains(t, err, "could not load template")
+	})
+
+	t.Run("errors if rendering fails", func(t *testing.T) {
+		curTmplString := aiMonitoringTmplString
+		t.Cleanup(func() {
+			aiMonitoringTmplString = curTmplString
+		})
+		aiMonitoringTmplString = "{{.Text}}"
+
+		err := RenderAiCompatDoc("testdata/ai-compat.json", io.Discard)
+		assert.ErrorContains(t, err, "failed to render template")
+	})
+}

--- a/flags.go
+++ b/flags.go
@@ -2,20 +2,18 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"slices"
-
 	"github.com/MakeNowJust/heredoc/v2"
 	flag "github.com/spf13/pflag"
+	"os"
 )
 
 type appFlags struct {
-	noExternals   bool
-	outputFormat  *StringEnumValue
-	replaceInFile string
-	repoDir       string
-	testDir       string
-	verbose       bool
+	aiCompatJsonFile string
+	noExternals      bool
+	replaceInFile    string
+	repoDir          string
+	testDir          string
+	verbose          bool
 
 	startMarker string
 	endMarker   string
@@ -37,6 +35,18 @@ func createAndParseFlags(args []string) error {
 		printUsage(fs.FlagUsages())
 	}
 
+	fs.StringVarP(
+		&flags.aiCompatJsonFile,
+		"ai-compat-json",
+		"a",
+		"",
+		heredoc.Doc(`
+			Path to the ai-compat.json file that describes the AI Monitoring
+			compatibility of the agent. The default is to use the JSON file included
+			in the mainline agent repository.
+		`),
+	)
+
 	fs.BoolVarP(
 		&flags.noExternals,
 		"no-externals",
@@ -47,20 +57,6 @@ func createAndParseFlags(args []string) error {
 			one that provides extra functionality to the "newrelic" module. This
 			allows processing a single repo with --repo-dir. The default, i.e. not
 			supplying this flag, is to process all known external repos.
-		`),
-	)
-
-	flags.outputFormat = NewStringEnumValue(
-		[]string{"ascii", "markdown"},
-		"markdown",
-	)
-	fs.VarP(
-		flags.outputFormat,
-		"output-format",
-		"o",
-		heredoc.Doc(`
-			Specify the format to write the results as. The default is an ASCII
-			table. Possible values: "ascii" or "markdown".
 		`),
 	)
 
@@ -140,39 +136,4 @@ func readEnvironment() {
 func printUsage(help string) {
 	fmt.Println(usageText)
 	fmt.Println(help)
-}
-
-// StringEnumValue is a custom [flag.Value] implementation that
-// allows a specific set of string values.
-// See https://github.com/spf13/pflag/issues/236#issuecomment-931600452
-type StringEnumValue struct {
-	allowed []string
-	value   string
-}
-
-// NewStringEnumValue creates a new [StringEnumValue] with a defined set of
-// allowed values and a sets the initial value to a default value (`def`).
-func NewStringEnumValue(allowed []string, def string) *StringEnumValue {
-	return &StringEnumValue{
-		allowed: allowed,
-		value:   def,
-	}
-}
-
-func (sev *StringEnumValue) String() string {
-	return sev.value
-}
-
-func (sev *StringEnumValue) Set(val string) error {
-	if slices.Contains(sev.allowed, val) == false {
-		return fmt.Errorf("%s is not an allowed value", val)
-	}
-
-	sev.value = val
-
-	return nil
-}
-
-func (sev *StringEnumValue) Type() string {
-	return "string"
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -9,44 +9,12 @@ func Test_createAndParseFlags(t *testing.T) {
 	t.Run("defaults are as expected", func(t *testing.T) {
 		err := createAndParseFlags([]string{"ignored"})
 		expected := appFlags{
-			noExternals: false,
-			outputFormat: &StringEnumValue{
-				allowed: []string{"ascii", "markdown"},
-				value:   "markdown",
-			},
-			startMarker: "{/* begin: compat-table */}",
-			endMarker:   "{/* end: compat-table */}",
+			aiCompatJsonFile: "",
+			noExternals:      false,
+			startMarker:      "{/* begin: compat-table */}",
+			endMarker:        "{/* end: compat-table */}",
 		}
 		assert.Nil(t, err)
 		assert.Equal(t, expected, flags)
-	})
-}
-
-func Test_StringEnumValue(t *testing.T) {
-	t.Run("only allows specified values", func(t *testing.T) {
-		sev := NewStringEnumValue([]string{"foo", "bar"}, "foo")
-		expected := &StringEnumValue{
-			allowed: []string{"foo", "bar"},
-			value:   "foo",
-		}
-		assert.Equal(t, expected, sev)
-
-		err := sev.Set("baz")
-		assert.ErrorContains(t, err, "baz is not an allowed value")
-
-		err = sev.Set("bar")
-		assert.Nil(t, err)
-		expected.value = "bar"
-		assert.Equal(t, expected, sev)
-	})
-
-	t.Run("supports interface methods", func(t *testing.T) {
-		sev := NewStringEnumValue([]string{"foo", "bar"}, "foo")
-		assert.Equal(t, "string", sev.Type())
-		assert.Equal(t, "foo", sev.String())
-
-		err := sev.Set("bar")
-		assert.Nil(t, err)
-		assert.Equal(t, "bar", sev.String())
 	})
 }

--- a/testdata/ai-compat.expected.md
+++ b/testdata/ai-compat.expected.md
@@ -43,7 +43,7 @@ Models/providers are generally supported transitively by our instrumentation of 
 
 Through the `openai` module, we support:
 
-| Completions | Chat | Embeddings | Files | Images | Audio |
+| Audio | Chat | Completions | Embeddings | Files | Images |
 | --- | --- | --- | --- | --- | --- |
-| ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
 

--- a/testdata/ai-compat.expected.md
+++ b/testdata/ai-compat.expected.md
@@ -6,13 +6,22 @@ The Node.js agent supports the following AI platforms and integrations.
 
 Through the `@aws-sdk/client-bedrock-runtime` module, we support:
 
-| Model | Text | Image |
+| Model | Image | Text |
 | --- | --- | --- |
-| Claude | ✅ | ❌ |
-| Cohere | ✅ | ❌ |
-
+| Claude | ❌ | ✅ |
+| Cohere | ❌ | ✅ |
 
 Note: if a model supports streaming, we also instrument the streaming variant.
+### Foo Gateway
+
+
+
+| Model | Four | One | Three | Two |
+| --- | --- | --- | --- | --- |
+| Foo Model | ✅ | ✅ | ❌ | ❌ |
+
+
+
 
 ### Langchain
 

--- a/testdata/ai-compat.expected.md
+++ b/testdata/ai-compat.expected.md
@@ -27,13 +27,11 @@ Note: if a model supports streaming, we also instrument the streaming variant.
 
 The following general features of Langchain are supported:
 
-| Agents | Chains | Vectorstores | Tools |
+| Agents | Chains | Tools | Vectorstores |
 | --- | --- | --- | --- |
-| ✅ | ✅ | ✅ | ❌ |
+| ✅ | ✅ | ✅ | ✅ |
 
-
-Models/providers are generally supported transitively by our instrumentation of
-the provider's module.
+Models/providers are generally supported transitively by our instrumentation of the provider's module.
 
 | Provider | Supported | Transitively |
 | --- | --- | --- |

--- a/testdata/ai-compat.expected.md
+++ b/testdata/ai-compat.expected.md
@@ -1,0 +1,42 @@
+## AI Monitoring Support
+
+The Node.js agent supports the following AI platforms and integrations.
+
+### Amazon Bedrock
+
+Through the `@aws-sdk/client-bedrock-runtime` module, we support:
+
+| Model | Text | Image |
+| --- | --- | --- |
+| Claude | ✅ | ❌ |
+| Cohere | ✅ | ❌ |
+
+
+Note: if a model supports streaming, we also instrument the streaming variant.
+
+### Langchain
+
+The following general features of Langchain are supported:
+
+| Agents | Chains | Vectorstores | Tools |
+| --- | --- | --- | --- |
+| ✅ | ✅ | ✅ | ❌ |
+
+
+Models/providers are generally supported transitively by our instrumentation of
+the provider's module.
+
+| Provider | Supported | Transitively |
+| --- | --- | --- |
+| Azure OpenAI | ❌ | ❌ |
+| OpenAI | ✅ | ✅ |
+
+
+### OpenAI
+
+Through the `openai` module, we support:
+
+| Completions | Chat | Embeddings | Files | Images | Audio |
+| --- | --- | --- | --- | --- | --- |
+| ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+

--- a/testdata/ai-compat.json
+++ b/testdata/ai-compat.json
@@ -91,6 +91,7 @@
   {
     "kind": "sdk",
     "title": "OpenAI",
+    "featuresPreamble": "Through the `openai` module, we support:",
     "features": [
       {
         "title": "Completions",

--- a/testdata/ai-compat.json
+++ b/testdata/ai-compat.json
@@ -54,6 +54,8 @@
   {
     "kind": "abstraction",
     "title": "Langchain",
+    "featuresPreamble": "The following general features of Langchain are supported:",
+    "providersPreamble": "Models/providers are generally supported transitively by our instrumentation of the provider's module.",
     "features": [
       {
         "title": "Agents",

--- a/testdata/ai-compat.json
+++ b/testdata/ai-compat.json
@@ -1,0 +1,101 @@
+[
+  {
+    "kind": "gateway",
+    "title": "Amazon Bedrock",
+    "models": [
+      {
+        "name": "Claude",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      },
+
+      {
+        "name": "Cohere",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    "kind": "abstraction",
+    "title": "Langchain",
+    "features": [
+      {
+        "title": "Agents",
+        "supported": true
+      },
+      {
+        "title": "Chains",
+        "supported": true
+      },
+      {
+        "title": "Vectorstores",
+        "supported": true
+      },
+      {
+        "title": "Tools",
+        "supported": true
+      }
+    ],
+    "providers": [
+      {
+        "name": "Azure OpenAI",
+        "supported": false,
+        "transitively": false
+      },
+      {
+        "name": "OpenAI",
+        "supported": true,
+        "transitively": true
+      }
+    ]
+  },
+
+  {
+    "kind": "sdk",
+    "title": "OpenAI",
+    "features": [
+      {
+        "title": "Completions",
+        "supported": true
+      },
+      {
+        "title": "Chat",
+        "supported": true
+      },
+      {
+        "title": "Embeddings",
+        "supported": true
+      },
+      {
+        "title": "Files",
+        "supported": false
+      },
+      {
+        "title": "Images",
+        "supported": false
+      },
+      {
+        "title": "Audio",
+        "supported": false
+      }
+    ]
+  }
+]

--- a/testdata/ai-compat.json
+++ b/testdata/ai-compat.json
@@ -2,6 +2,8 @@
   {
     "kind": "gateway",
     "title": "Amazon Bedrock",
+    "preamble": "Through the `@aws-sdk/client-bedrock-runtime` module, we support:",
+    "footnote": "Note: if a model supports streaming, we also instrument the streaming variant.",
     "models": [
       {
         "name": "Claude",
@@ -28,6 +30,22 @@
             "title": "Image",
             "supported": false
           }
+        ]
+      }
+    ]
+  },
+
+  {
+    "kind": "gateway",
+    "title": "Foo Gateway",
+    "models": [
+      {
+        "name": "Foo Model",
+        "features": [
+          {"title": "One", "supported": true},
+          {"title": "Two", "supported": false},
+          {"title": "Three", "supported": false},
+          {"title": "Four", "supported": true}
         ]
       }
     ]

--- a/tmpl/ai-monitoring-support.md
+++ b/tmpl/ai-monitoring-support.md
@@ -24,12 +24,10 @@ The Node.js agent supports the following AI platforms and integrations.
 {{providersToTable .Providers}}
 {{end}}
 
-### OpenAI
+{{range .Sdks -}}
+### {{.Title}}
 
-Through the `openai` module, we support:
+{{if .FeaturesPreamble}}{{.FeaturesPreamble}}{{end}}
 
-| Completions | Chat | Embeddings | Files | Images | Audio |
-| --- | --- | --- | --- | --- | --- |
-{{- with .Openai}}
-| {{boolEmoji .Completions}} | {{boolEmoji .Chat}} | {{boolEmoji .Embeddings}} | {{boolEmoji .Files}} | {{boolEmoji .Images}} | {{boolEmoji .Audio}} |
+{{featuresToTable .Features}}
 {{end}}

--- a/tmpl/ai-monitoring-support.md
+++ b/tmpl/ai-monitoring-support.md
@@ -2,17 +2,15 @@
 
 The Node.js agent supports the following AI platforms and integrations.
 
-### Amazon Bedrock
+{{range .Gateways -}}
+### {{.Title}}
 
-Through the `@aws-sdk/client-bedrock-runtime` module, we support:
+{{if .Preamble}}{{.Preamble}}{{end}}
 
-| Model | Text | Image |
-| --- | --- | --- |
-{{range .Bedrock.Models -}}
-| {{.Name}} | {{boolEmoji .Text}} | {{boolEmoji .Image}} |
+{{gatewayModelsToTable .Models}}
+
+{{if .Footnote}}{{.Footnote}}{{end}}
 {{end}}
-
-Note: if a model supports streaming, we also instrument the streaming variant.
 
 ### Langchain
 

--- a/tmpl/ai-monitoring-support.md
+++ b/tmpl/ai-monitoring-support.md
@@ -1,0 +1,44 @@
+## AI Monitoring Support
+
+The Node.js agent supports the following AI platforms and integrations.
+
+### Amazon Bedrock
+
+Through the `@aws-sdk/client-bedrock-runtime` module, we support:
+
+| Model | Text | Image |
+| --- | --- | --- |
+{{range .Bedrock.Models -}}
+| {{.Name}} | {{boolEmoji .Text}} | {{boolEmoji .Image}} |
+{{end}}
+
+Note: if a model supports streaming, we also instrument the streaming variant.
+
+### Langchain
+
+The following general features of Langchain are supported:
+
+| Agents | Chains | Vectorstores | Tools |
+| --- | --- | --- | --- |
+{{- with .Langchain.Features}}
+| {{boolEmoji .Agents}} | {{boolEmoji .Chains}} | {{boolEmoji .Vectorstores}} | {{boolEmoji .Tools}} |
+{{end}}
+
+Models/providers are generally supported transitively by our instrumentation of
+the provider's module.
+
+| Provider | Supported | Transitively |
+| --- | --- | --- |
+{{range .Langchain.Providers -}}
+| {{.Name}} | {{boolEmoji .Supported}} | {{boolEmoji .Transitively}} |
+{{end}}
+
+### OpenAI
+
+Through the `openai` module, we support:
+
+| Completions | Chat | Embeddings | Files | Images | Audio |
+| --- | --- | --- | --- | --- | --- |
+{{- with .Openai}}
+| {{boolEmoji .Completions}} | {{boolEmoji .Chat}} | {{boolEmoji .Embeddings}} | {{boolEmoji .Files}} | {{boolEmoji .Images}} | {{boolEmoji .Audio}} |
+{{end}}

--- a/tmpl/ai-monitoring-support.md
+++ b/tmpl/ai-monitoring-support.md
@@ -12,23 +12,16 @@ The Node.js agent supports the following AI platforms and integrations.
 {{if .Footnote}}{{.Footnote}}{{end}}
 {{end}}
 
-### Langchain
+{{range .Abstractions -}}
+### {{.Title}}
 
-The following general features of Langchain are supported:
+{{if .FeaturesPreamble}}{{.FeaturesPreamble}}{{end}}
 
-| Agents | Chains | Vectorstores | Tools |
-| --- | --- | --- | --- |
-{{- with .Langchain.Features}}
-| {{boolEmoji .Agents}} | {{boolEmoji .Chains}} | {{boolEmoji .Vectorstores}} | {{boolEmoji .Tools}} |
-{{end}}
+{{featuresToTable .Features}}
 
-Models/providers are generally supported transitively by our instrumentation of
-the provider's module.
+{{if .ProvidersPreamble}}{{.ProvidersPreamble}}{{end}}
 
-| Provider | Supported | Transitively |
-| --- | --- | --- |
-{{range .Langchain.Providers -}}
-| {{.Name}} | {{boolEmoji .Supported}} | {{boolEmoji .Transitively}} |
+{{providersToTable .Providers}}
 {{end}}
 
 ### OpenAI


### PR DESCRIPTION
This PR is in support of https://github.com/newrelic/node-newrelic/issues/2253.

This PR adds support for processing and rendering our AI Monitoring compatibility configuration JSON added by https://github.com/newrelic/node-newrelic/pull/2249. We should only have to update the JSON file (at least in most of the cases) and not have to touch the code in this tool going forward in order to describe any new AI Monitor capabilities.

<details>
<summary>Example output</summary>


```md
## Instrumented modules

After installation, the agent automatically instruments with our catalog of
supported Node.js libraries and frameworks. This gives you immediate access to
granular information specific to your web apps and servers.  For unsupported
frameworks or libraries, you'll need to instrument the agent yourself using the
[Node.js agent API](https://newrelic.github.io/node-newrelic/API.html).

**Note**: The latest supported version may not reflect the most recent supported
version.

| Package name | Minimum supported version | Latest supported version | Introduced in* |
| --- | --- | --- | --- |
| `@apollo/gateway` | 2.3.0 | 2.8.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `@apollo/server` | 4.0.0 | 4.10.4 | `@newrelic/apollo-server-plugin@2.1.0` |
| `@aws-sdk/client-bedrock-runtime` | 3.0.0 | 3.592.0 | 11.13.0 |
| `@aws-sdk/client-dynamodb` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/client-sns` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/client-sqs` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/smithy-client` | 3.0.0 | 3.374.0 | 8.7.1 |
| `@elastic/elasticsearch` | 7.16.0 | 8.13.1 | 11.9.0 |
| `@grpc/grpc-js` | 1.4.0 | 1.10.8 | 8.17.0 |
| `@hapi/hapi` | 20.1.2 | 21.3.9 | 9.0.0 |
| `@koa/router` | 2.0.0 | 12.0.1 | 3.2.0 |
| `@langchain/core` | 0.1.17 | 0.2.6 | 11.13.0 |
| `@nestjs/cli` | 8.0.0 | 10.3.2 | 10.1.0 |
| `@prisma/client` | 5.0.0 | 5.15.0 | 11.0.0 |
| `@smithy/smithy-client` | 3.0.0 | 3.1.1 | 11.0.0 |
| `amqplib` | 0.5.0 | 0.10.4 | 2.0.0 |
| `apollo-server` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-express` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-fastify` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-hapi` | 3.0.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-koa` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-lambda` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `aws-sdk` | 2.2.48 | 2.1637.0 | 6.2.0 |
| `bluebird` | 2.0.0 | 3.7.2 | 1.27.0 |
| `bunyan` | 1.8.12 | 1.8.15 | 9.3.0 |
| `cassandra-driver` | 3.4.0 | 4.7.2 | 1.7.1 |
| `connect` | 2.0.0 | 3.7.0 | 2.6.0 |
| `director` | 1.2.0 | 1.2.8 | 2.0.0 |
| `express` | 4.6.0 | 4.19.2 | 2.6.0 |
| `fastify` | 2.0.0 | 4.27.0 | 8.5.0 |
| `generic-pool` | 2.4.0 | 3.9.0 | 0.9.0 |
| `ioredis` | 3.0.0 | 5.4.1 | 1.26.2 |
| `koa` | 2.0.0 | 2.15.3 | 3.2.0 |
| `koa-route` | 2.0.0 | 4.0.1 | 3.2.0 |
| `koa-router` | 2.0.0 | 12.0.1 | 3.2.0 |
| `memcached` | 2.2.0 | 2.2.2 | 1.26.2 |
| `mongodb` | 2.1.0 | 6.7.0 | 1.32.0 |
| `mysql` | 2.2.0 | 2.18.1 | 1.32.0 |
| `mysql2` | 1.3.1 | 3.10.0 | 1.32.0 |
| `next` | 13.0.0 | 14.2.3 | `@newrelic/next@0.7.0` |
| `openai` | 4.0.0 | 4.49.1 | 11.13.0 |
| `pg` | 8.2.0 | 8.12.0 | 9.0.0 |
| `pg-native` | 2.0.0 | 3.1.0 | 9.0.0 |
| `pino` | 7.0.0 | 9.1.0 | 8.11.0 |
| `q` | 1.3.0 | 1.5.1 | 1.26.2 |
| `redis` | 2.0.0 | 4.6.14 | 1.31.0 |
| `restify` | 5.0.0 | 11.1.0 | 2.6.0 |
| `superagent` | 2.0.0 | 9.0.2 | 4.9.0 |
| `undici` | 4.7.0 | 6.18.2 | 11.1.0 |
| `when` | 3.7.0 | 3.7.8 | 1.26.2 |
| `winston` | 3.0.0 | 3.13.0 | 8.11.0 |

*When package is not specified, support is within the `newrelic` package.

## AI Monitoring Support

The Node.js agent supports the following AI platforms and integrations.

### Amazon Bedrock

Through the `@aws-sdk/client-bedrock-runtime` module, we support:

| Model | Image | Text |
| --- | --- | --- |
| Claude | ❌ | ✅ |
| Cohere | ❌ | ✅ |
| Jurassic-2 | ❌ | ✅ |
| Llama2 | ❌ | ✅ |
| Titan | ❌ | ✅ |

Note: if a model supports streaming, we also instrument the streaming variant.


### Langchain

The following general features of Langchain are supported:

| Agents | Chains | Tools | Vectorstores |
| --- | --- | --- | --- |
| ✅ | ✅ | ✅ | ✅ |

Models/providers are generally supported transitively by our instrumentation of the provider's module.

| Provider | Supported | Transitively |
| --- | --- | --- |
| Azure OpenAI | ❌ | ❌ |
| Amazon Bedrock | ❌ | ❌ |
| OpenAI | ✅ | ✅ |


### OpenAI

Through the `openai` module, we support:

| Audio | Chat | Completions | Embeddings | Files | Images |
| --- | --- | --- | --- | --- | --- |
| ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |

```

</details>