### PR TITLE
chore: Added support for mismatched model features in gateways

### DIFF
--- a/ai-compat-types_test.go
+++ b/ai-compat-types_test.go
@@ -28,6 +28,7 @@ func Test_AiCompatJson(t *testing.T) {
 				Features: []AiCompatFeature{
 					{"Text", true},
 					{"Image", false},
+					{"Vision", false},
 				},
 			},
 			{

--- a/testdata/ai-compat.expected.md
+++ b/testdata/ai-compat.expected.md
@@ -6,10 +6,10 @@ The Node.js agent supports the following AI platforms and integrations.
 
 Through the `@aws-sdk/client-bedrock-runtime` module, we support:
 
-| Model | Image | Text |
-| --- | --- | --- |
-| Claude | ❌ | ✅ |
-| Cohere | ❌ | ✅ |
+| Model | Image | Text | Vision |
+| --- | --- | --- | --- |
+| Claude | ❌ | ✅ | ❌ |
+| Cohere | ❌ | ✅ | - |
 
 Note: if a model supports streaming, we also instrument the streaming variant.
 ### Foo Gateway
@@ -18,6 +18,7 @@ Note: if a model supports streaming, we also instrument the streaming variant.
 
 | Model | Four | One | Three | Two |
 | --- | --- | --- | --- | --- |
+| Bar Model | - | ✅ | ❌ | - |
 | Foo Model | ✅ | ✅ | ❌ | ❌ |
 
 

--- a/testdata/ai-compat.json
+++ b/testdata/ai-compat.json
@@ -15,6 +15,10 @@
           {
             "title": "Image",
             "supported": false
+          },
+          {
+            "title": "Vision",
+            "supported": false
           }
         ]
       },
@@ -46,6 +50,13 @@
           {"title": "Two", "supported": false},
           {"title": "Three", "supported": false},
           {"title": "Four", "supported": true}
+        ]
+      },
+      {
+        "name": "Bar Model",
+        "features": [
+          {"title": "One", "supported":  true},
+          {"title": "Three", "supported":  false}
         ]
       }
     ]


### PR DESCRIPTION
While working on https://github.com/newrelic/node-newrelic/issues/2243, I discovered that we will need to consider mismatched feature sets between models. For example, the Anthropic Claude v3 model supports a "Vision" feature that our existing models do not. With this PR, models within gateway declarations can have arbitrary features listed, and models that do not share features will have gap columns added (most easily understood by looking at the expected output fixture).