### PR TITLE
fix: Fixed logic in parsing of minimum supported versions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -90,7 +90,7 @@ func Test_processVersionedTestDirs(t *testing.T) {
 
 		releaseData := processVersionedTestDirs(testDirs, logger)
 		assert.Equal(t, 0, len(collector.logs))
-		assert.Equal(t, 3, len(releaseData))
+		assert.Equal(t, 7, len(releaseData))
 	})
 }
 

--- a/parse-package.go
+++ b/parse-package.go
@@ -90,6 +90,7 @@ func parsePackage(pkg *VersionedTestPackageJson) ([]PkgInfo, error) {
 			MinAgentVersion: target.MinAgentVersion,
 		}
 		results = append(results, pkgInfo)
+		lastVersion = nil
 	}
 
 	return results, nil

--- a/parse-package_test.go
+++ b/parse-package_test.go
@@ -38,6 +38,31 @@ func Test_ParsePackage(t *testing.T) {
 		}})
 	})
 
+	t.Run("handles multiple packages in one descriptor", func(t *testing.T) {
+		testPkg(t, "testdata/versioned/koa/package.json", []PkgInfo{
+			{
+				Name:            "koa",
+				MinVersion:      "2.0.0",
+				MinAgentVersion: "3.2.0",
+			},
+			{
+				Name:            "koa-route",
+				MinVersion:      "3.0.0",
+				MinAgentVersion: "3.2.0",
+			},
+			{
+				Name:            "koa-router",
+				MinVersion:      "7.1.0",
+				MinAgentVersion: "3.2.0",
+			},
+			{
+				Name:            "@koa/router",
+				MinVersion:      "8.0.0",
+				MinAgentVersion: "3.2.0",
+			},
+		})
+	})
+
 	t.Run("handles @langchain/core", func(t *testing.T) {
 		testPkg(t, "testdata/versioned/langchain/package.json", []PkgInfo{{
 			Name:            "@langchain/core",

--- a/testdata/versioned/koa/package.json
+++ b/testdata/versioned/koa/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "koa-tests",
+  "targets": [
+    {"name": "koa", "minAgentVersion": "3.2.0"},
+    {"name": "koa-route", "minAgentVersion": "3.2.0"},
+    {"name": "koa-router", "minAgentVersion": "3.2.0"},
+    {"name": "@koa/router", "minAgentVersion": "3.2.0"}
+  ],
+  "version": "0.0.0",
+  "private": true,
+  "tests": [
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "koa": {
+          "versions": ">=2.0.0",
+          "samples": 5
+        }
+      },
+      "files": [
+        "koa.tap.js",
+        "code-level-metrics.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "koa": {
+          "versions": ">=2.0.0",
+          "samples": 5
+        },
+        "koa-router": {
+          "versions": ">=7.1.0",
+          "samples": 5
+        }
+      },
+      "files": [
+        "koa-router.tap.js",
+        "code-level-metrics.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "koa": {
+          "versions": ">=2.0.0",
+          "samples": 5
+        },
+        "@koa/router": {
+          "versions": ">=8.0.0",
+          "samples": 5
+        }
+      },
+      "files": [
+        "scoped-koa-router.tap.js",
+        "code-level-metrics.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "koa": {
+          "versions": ">=2.0.0",
+          "samples": 5
+        },
+        "koa-route": {
+          "versions": ">=3.0.0",
+          "samples": 5
+        }
+      },
+      "files": [
+        "koa-route.tap.js"
+      ]
+    }
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
We forgot to reset the tracking variable, and so things got stuck.