### PR TITLE
docs: Removed SECURITY.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ We encourage your contributions to improve newrelic-node-versions! Keep in mind 
 If you have any questions, or to execute our corporate CLA (which is required if your contribution is on behalf of a company), drop us an email at opensource@newrelic.com.
 
 **A note about vulnerabilities**
-As noted in our [security policy](./SECURITY.md), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
+As noted in our [security policy](https://github.com/newrelic/newrelic-node-versions/security/policy), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
 
 If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [our bug bounty program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,0 @@
-# Reporting Security Vulnerabilities
-
-New Relic is committed to the security of our customers and your data. We believe that engaging with security researchers through our coordinated disclosure program is an important means to achieve our security goals.
-
-If you believe you have found a security vulnerability in one of our products or websites, we welcome and greatly appreciate you reporting it to New Relic's coordinated disclosure program.  Please see our [website for more information on how to report a vulnerability](https://docs.newrelic.com/docs/security/new-relic-security/data-privacy/reporting-security-vulnerabilities).
-


### PR DESCRIPTION
This PR is to remove the SECURITY.md file from the repository, as SECURITY.md files are centrally managed in the organization's [.github](https://github.com/newrelic/.github) repository. This allows for easy updates made by security in the future.