### PR TITLE
tweaked language around most recent published version

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var externalsRepos = []nrRepo{
 var columHeaders = map[string]string{
 	"Name":                `Package name`,
 	"MinSupportedVersion": `Minimum supported version`,
-	"LatestVersion":       `Latest supported version`,
+	"LatestVersion":       `Latest published version`,
 	"MinAgentVersion":     `Introduced in*`,
 }
 

--- a/testdata/data-table.expected.md
+++ b/testdata/data-table.expected.md
@@ -1,4 +1,4 @@
-| Package name | Minimum supported version | Latest supported version | Introduced in* |
+| Package name | Minimum supported version | Latest published version | Introduced in* |
 | --- | --- | --- | --- |
 | `foo` | 1.0.0 | 2.0.0 | 2.0.0 |
 | `@foo/bar` | 1.0.0 | 2.0.0 | `@newrelic/foo-bar@1.0.0` |

--- a/tmpl/preamble.md
+++ b/tmpl/preamble.md
@@ -6,5 +6,5 @@ granular information specific to your web apps and servers.  For unsupported
 frameworks or libraries, you'll need to instrument the agent yourself using the
 [Node.js agent API](https://newrelic.github.io/node-newrelic/API.html).
 
-**Note**: The latest supported version may not reflect the most recent supported
-version.
+**Note**: The latest published version may not reflect the most recent version
+supported by the agent.


### PR DESCRIPTION
This PR tweaks the language used to describe the third column of the supported modules table. It should be easier to understand that the column is showing what the latest version of the module is, but not necessarily that the version is supported by the agent.